### PR TITLE
build(deps): bump brand and seller api from 2.0.1 to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "license": "proprietary",
     "type": "metapackage",
     "require": {
-        "marketplacer/magento2-plugin-base": "~2.0.0",
-        "marketplacer/magento2-plugin-seller-api": "~2.0.0",
-        "marketplacer/magento2-plugin-brand-api": "~2.0.0",
-        "marketplacer/magento2-plugin-seller": "~2.0.0",
-        "marketplacer/magento2-plugin-brand": "~2.0.0",
-        "marketplacer/magento2-plugin-marketplacer": "~2.0.0"
+        "marketplacer/magento2-plugin-base": "~2.0.1",
+        "marketplacer/magento2-plugin-seller-api": "~2.0.2",
+        "marketplacer/magento2-plugin-brand-api": "~2.0.2",
+        "marketplacer/magento2-plugin-seller": "~2.0.1",
+        "marketplacer/magento2-plugin-brand": "~2.0.1",
+        "marketplacer/magento2-plugin-marketplacer": "~2.0.1"
     }
 }


### PR DESCRIPTION
Bump dependencies to fix multi shipping issue

**Release Checklist:**
<!-- tick the box to show you thought about it, but give more info if you made changes. -->
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.